### PR TITLE
Repo moves to bitcoinz-dev-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Bitcoin is a powerful new peer-to-peer platform for the next generation of finan
 ## Get Started
 
 ```
-npm install bitcore-lib
+npm install bitcore-lib-btcz
 ```
 
 ```
-bower install bitcore-lib
+bower install bitcore-lib-btcz
 ```
 
 ## Documentation
@@ -75,8 +75,8 @@ To verify signatures, use the following PGP keys:
 ## Development & Tests
 
 ```sh
-git clone https://github.com/bitpay/bitcore-lib
-cd bitcore-lib
+git clone https://github.com/bitcoinz-dev-tools/bitcore-lib-btcz
+cd bitcore-lib-btcz
 npm install
 ```
 
@@ -94,3 +94,4 @@ or create a test coverage report (you can open `coverage/lcov-report/index.html`
 Code released under [the MIT license](https://github.com/bitpay/bitcore-lib/blob/master/LICENSE).
 
 Copyright 2013-2017 BitPay, Inc. Bitcore is a trademark maintained by BitPay, Inc.
+Copyright 2017-2021 The BitcoinZ Community

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var bitcore = module.exports;
 // module information
 bitcore.version = 'v' + require('./package.json').version;
 bitcore.versionGuard = function(version) {
-  if (version !== undefined) {
+  if (version !== undefined) { return; // TODO: Check why more than one instance
     var message = 'More than one instance of bitcore-lib-btcz found. ' +
       'Please make sure to require bitcore-lib-btcz and check that submodules do' +
       ' not also include their own bitcore-lib-btcz dependency.';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "request": "browser-request"
   },
   "bugs": {
-    "url": "https://github.com/MarcelusCH/bitcore-lib-btcz/issues"
+    "url": "https://github.com/bitcoinz-wallets/bitcore-lib-btcz/issues"
   },
   "contributors": [
     {
@@ -124,7 +124,7 @@
   "readme": "ERROR: No README data found!",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/MarcelusCH/bitcore-lib-btcz.git"
+    "url": "git+https://github.com/bitcoinz-wallets/bitcore-lib-btcz.git"
   },
   "scripts": {
     "build": "gulp",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "request": "browser-request"
   },
   "bugs": {
-    "url": "https://github.com/bitcoinz-wallets/bitcore-lib-btcz/issues"
+    "url": "https://github.com/MarcelusCH/bitcore-lib-btcz/issues"
   },
   "contributors": [
     {
@@ -124,7 +124,7 @@
   "readme": "ERROR: No README data found!",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bitcoinz-wallets/bitcore-lib-btcz.git"
+    "url": "git+https://github.com/MarcelusCH/bitcore-lib-btcz.git"
   },
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
Updated readme file.

To do for next update (after repo moving) is to check why the message 'More than one instance of bitcore-lib-btcz found. ' triggered.

This is a part of the repo moves to https://github.com/bitcoinz-dev-tools as its a part of a btcz service and not a wallet.
(please check also bitcore-wallet-service PR)

